### PR TITLE
handle more cases

### DIFF
--- a/nomovdo.js
+++ b/nomovdo.js
@@ -11,7 +11,7 @@ function killVideo(video) {
 
 function nomovdo(element) {
 	document.querySelectorAll("video").forEach(function(video) {
-		if(flaggedVideos.has(video)) { return; }
+		if(!video.src && video.childElementCount === 0 && flaggedVideos.has(video)) { return; }
 
 		flaggedVideos.add(video);
 


### PR DESCRIPTION
With the previous logic, once a video
is added to the flagged set it's no longer
checked so if a site creates the video tag,
adds it to the document and then later
sets a src a video would still play

So, this change checks that video.src
is falsey and that the video has no
children (assumed to be <source> elements).

#1 